### PR TITLE
Modified blockquote styles

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -17,3 +17,9 @@
     flex-wrap:wrap;
   }
 }
+
+// modified blockquote styles
+article blockquote p {
+  margin: 1em 0;
+  font-style: normal;
+}


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/bca9bffa-fa93-4edb-8419-445e918d59c0)

After:
![image](https://github.com/user-attachments/assets/f527840f-506c-4733-888e-8b006d6ee444)

Closes #52 