### PR TITLE
Modified heading font size

### DIFF
--- a/quartz/plugins/transformers/toc.ts
+++ b/quartz/plugins/transformers/toc.ts
@@ -40,7 +40,7 @@ export const TableOfContents: QuartzTransformerPlugin<Partial<Options>> = (userO
               slugAnchor.reset()
               const toc: TocEntry[] = []
               let highestDepth: number = opts.maxDepth
-              const excludedNodes: Heading[] = [];
+              let excludedNodes: Heading[] = [];
 
               visit(tree, "blockquote", (node) => {
                 const heading = find(node, (node: any) => {
@@ -49,6 +49,8 @@ export const TableOfContents: QuartzTransformerPlugin<Partial<Options>> = (userO
 
                 excludedNodes.push(heading as Heading);
               })
+
+              excludedNodes = excludedNodes.filter(e => !!e);
 
               visit(tree, "heading", (node) => {
                 if (node.depth <= opts.maxDepth) {

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -124,9 +124,9 @@ a {
   max-width: calc(#{map-get($breakpoints, desktop)} + 300px);
   margin: 0 auto;
   & article {
-    & > h1 {
-      font-size: 2rem;
-    }
+    // & > h1 {
+    //   font-size: 2rem;
+    // }
 
     & li:has(> input[type="checkbox"]) {
       list-style-type: none;

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -17,3 +17,14 @@
     flex-wrap:wrap;
   }
 }
+
+// modified article-title style
+.article-title {
+  font-size: 2rem;
+
+  @media all and not ($desktop) {
+    & {
+      font-size: 1.75rem;
+    }
+  }
+}


### PR DESCRIPTION
Note: I've added the "Heading 1, Heading 2, etc" texts for demo purposes only.

Before:
![image](https://github.com/user-attachments/assets/38e6364a-11ef-4967-a412-2a07f3e53559)

After:
![image](https://github.com/user-attachments/assets/ca62f1b7-a63c-4225-807b-d9fb07b0b7c9)

Also fixed an issue on Table of Content not showing on other pages such as Theobald Clayhollow.md. Only in desktop.

Closes #58
